### PR TITLE
Pulled out release-notes and TODOs from script into separate files.

### DIFF
--- a/25318.user.js
+++ b/25318.user.js
@@ -24,46 +24,6 @@
 // @downloadURL    http://userscripts.org:8080/scripts/source/25318.user.js
 // http://wiki.videolan.org/Documentation:WebPlugin
 // Tested on Arch linux, Fx35+, vlc 2.1.5, (or vlc-git & npapi-vlc-git from AUR)
-//TODO cleanup on aisle 3
-//2014-06-25 Fix deciphering for firefox v30 and below
-//2014-05-21 Try to resume if unexpected EOS. Use bind(). Playlist next item fix.
-//2014-04-26 Watch later, regex fix, remove from watch later if viewing WL playlist, hover controls css
-//2014-04-26 Embedded crash. seekTo
-//2014-04-26 Incomplete quick fix the fix the fix for comments not loading, API calls maybe
-//2014-04-25 Fake Live formats for priority map
-//2014-04-24 Separate url map parse from DOM generation so we can fail earlier
-//           and allow flashplayer to take over. May need manual refreshing with SPF.
-//2014-04-24 this -> that. Embed font/css for icons
-//2014-04-24 Cleanup
-//2014-04-24 Alternate method for / quick fix for popups (security errors)
-//2014-04-17 Testing font Awesome Icons
-//2014-04-17 Option to auto select subtitle
-//2014-04-10 focus() leads to random scroll
-//2014-04-07 Signature deciphering flippity-boppity -_-
-//2014-03-30 Signature deciphering. Call focus() on vlc plugin
-//2014-03-13 Watch Later button option
-//2014-03-11 Fixed the playlist?
-//2014-03-10 Jump to timestamp option
-//2014-03-01 CSS hacks and fix some margins
-//2014-02-07 Fix popup. User page > video transition is borked still
-//2014-01-21 Live HLS stream test
-//2014-01-20 Can transition from main page > search results > video or user page > video without shitting itself?
-//2014-01-17 Thumbnails
-//2014-01-17 SPF hooking and volume restore changes
-//2014-01-17 Quick (aka not complete) fix for extra ajaxy 'tube
-//2014-01-06 Call stateUpdate on spf nav.
-//2014-01-04 Pass unsafeWindow to tampermonkey
-//2014-01-03 Mute button test
-
-//TODO that=this to bind()
-//TODO https://www.youtube.com/watch?v=IHGEdi6HblI  rtmpe
-//cipher https://www.youtube.com/watch?v=tka1jPGMyOs
-//stream http://www.youtube.com/watch?v=jrZcAsPKK74
-//ciphered http://www.youtube.com/watch?v=6CTHwEZK2JA
-//unavail https://www.youtube.com/watch?v=gSEzGDzZ1dY
-//has/had non-dash 1080p http://www.youtube.com/watch?v=-MJiR5IksEk
-//subtitle test https://www.youtube.com/watch?v=sqll1Rib93g
-//state play: 1, pause: 2, stop/end: 0
 
 (function(){
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -54,32 +54,33 @@
 
 
 ##Older
-//2014-06-25 Fix deciphering for firefox v30 and below
-//2014-05-21 Try to resume if unexpected EOS. Use bind(). Playlist next item fix.
-//2014-04-26 Watch later, regex fix, remove from watch later if viewing WL playlist, hover controls css
-//2014-04-26 Embedded crash. seekTo
-//2014-04-26 Incomplete quick fix the fix the fix for comments not loading, API calls maybe
-//2014-04-25 Fake Live formats for priority map
-//2014-04-24 Separate url map parse from DOM generation so we can fail earlier
-//           and allow flashplayer to take over. May need manual refreshing with SPF.
-//2014-04-24 this -> that. Embed font/css for icons
-//2014-04-24 Cleanup
-//2014-04-24 Alternate method for / quick fix for popups (security errors)
-//2014-04-17 Testing font Awesome Icons
-//2014-04-17 Option to auto select subtitle
-//2014-04-10 focus() leads to random scroll
-//2014-04-07 Signature deciphering flippity-boppity -_-
-//2014-03-30 Signature deciphering. Call focus() on vlc plugin
-//2014-03-13 Watch Later button option
-//2014-03-11 Fixed the playlist?
-//2014-03-10 Jump to timestamp option
-//2014-03-01 CSS hacks and fix some margins
-//2014-02-07 Fix popup. User page > video transition is borked still
-//2014-01-21 Live HLS stream test
-//2014-01-20 Can transition from main page > search results > video or user page > video without shitting itself?
-//2014-01-17 Thumbnails
-//2014-01-17 SPF hooking and volume restore changes
-//2014-01-17 Quick (aka not complete) fix for extra ajaxy 'tube
-//2014-01-06 Call stateUpdate on spf nav.
-//2014-01-04 Pass unsafeWindow to tampermonkey
-//2014-01-03 Mute button test
+```
+2014-06-25 Fix deciphering for firefox v30 and below
+2014-05-21 Try to resume if unexpected EOS. Use bind(). Playlist next item fix.
+2014-04-26 Watch later, regex fix, remove from watch later if viewing WL playlist, hover controls css
+2014-04-26 Embedded crash. seekTo
+2014-04-26 Incomplete quick fix the fix the fix for comments not loading, API calls maybe
+2014-04-25 Fake Live formats for priority map
+2014-04-24 Separate url map parse from DOM generation so we can fail earlier and allow flashplayer to take over. May need manual refreshing with SPF.
+2014-04-24 this -> that. Embed font/css for icons
+2014-04-24 Cleanup
+2014-04-24 Alternate method for / quick fix for popups (security errors)
+2014-04-17 Testing font Awesome Icons
+2014-04-17 Option to auto select subtitle
+2014-04-10 focus() leads to random scroll
+2014-04-07 Signature deciphering flippity-boppity -_-
+2014-03-30 Signature deciphering. Call focus() on vlc plugin
+2014-03-13 Watch Later button option
+2014-03-11 Fixed the playlist?
+2014-03-10 Jump to timestamp option
+2014-03-01 CSS hacks and fix some margins
+2014-02-07 Fix popup. User page > video transition is borked still
+2014-01-21 Live HLS stream test
+2014-01-20 Can transition from main page > search results > video or user page > video without shitting itself?
+2014-01-17 Thumbnails
+2014-01-17 SPF hooking and volume restore changes
+2014-01-17 Quick (aka not complete) fix for extra ajaxy 'tube
+2014-01-06 Call stateUpdate on spf nav.
+2014-01-04 Pass unsafeWindow to tampermonkey
+2014-01-03 Mute button test
+```

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,85 @@
+##In Development
+
+[Adjust compact volume button height](https://github.com/jackun/VLCTube/pull/52)
+[Visually limit scrollbar's knob's min/max size or position.](https://github.com/jackun/VLCTube/commit/b7af86cda7eaf0bff5de82beb7004b18902db677)
+[Just call play() on thumbnail click so jump-to-timestamp works then too.](https://github.com/jackun/VLCTube/commit/7c5ae4c9574c3cee8d605201b05fa052b109189e)
+
+[Commits](https://github.com/jackun/VLCTube/compare/v59.7...master)
+
+###v59.7 - 2015-03-18
+[Don't jump to timestamp when pausing/playing with play button.](https://github.com/jackun/VLCTube/commit/b386754c5cc631d0b1a51e66bff0fdbdf971e109)
+[Added customizable preset playback rate button as per issue #47.](https://github.com/jackun/VLCTube/pull/50)
+
+[Commits](https://github.com/jackun/VLCTube/compare/v59.6...v59.7)
+
+###v59.6 - 2015-03-15
+[Add cache setting.](https://github.com/jackun/VLCTube/commit/14429032db237426df37538a223f869b8493a2e7)
+
+[Commits](https://github.com/jackun/VLCTube/compare/v59.5...v59.6)
+
+###v59.5 - 2015-02-23
+[Delay player loading when SPF navigating. Images etc should load now.](https://github.com/jackun/VLCTube/commit/cf1ead1093a8e38ed04deae5c1ef07b43916dc6f)
+[Exclude a embedding site if 'controls=0'. May have a custom player.](https://github.com/jackun/VLCTube/commit/9975631b9286cdc4f82103a306f3302e7d5d64e5)
+
+[Commits](https://github.com/jackun/VLCTube/compare/v59.4...v59.5)
+
+###v59.4 - 2015-02-23
+[Exclude embedding sites: wimp.com (uses JW Player)](https://github.com/jackun/VLCTube/commit/e450d6813343092aef9796db95f56adbefb8144f)
+[Remove MPD generation. VLC can't play it anyway.](https://github.com/jackun/VLCTube/commit/28a9a7f2eee19c6754d9245d950c2906ccffa17e)
+[Nicer thumbnail.](https://github.com/jackun/VLCTube/commit/2ccca70182d8716979aa4ad392801f023520da64)
+
+[Commits](https://github.com/jackun/VLCTube/compare/v59.3...v59.4)
+
+###v59.3 - 2015-02-22
+[Skip unavailable videos when SPF is enabled.](https://github.com/jackun/VLCTube/commit/b8265c4cd2b6708658206374e0ffa1b487d26c02)
+
+[Commits](https://github.com/jackun/VLCTube/compare/v59.2...v59.3)
+
+###v59.2 - 2015-02-22
+[Can do away with waiting for yt.pubsub maybe.](https://github.com/jackun/VLCTube/commit/bc7021a61aa6549a5a6b995d4f8f35cda5da4bdf)
+
+[Commits](https://github.com/jackun/VLCTube/compare/v59.1...v59.2)
+
+##v59.1 - 2015-02-22
+[Update README.md](https://github.com/jackun/VLCTube/commit/18607e782883b74f2c70112e2becd83cad1f49d0)
+
+[Commits](https://github.com/jackun/VLCTube/compare/v59...v59.1)
+
+##v59 - 2015-02-22
+[Try to delay loading the player until some javascript variables have been loaded.](https://github.com/jackun/VLCTube/commit/24f068746b02cab28d7b24b1b306bb51d10c6c4d)
+[Remove feather stuff.](https://github.com/jackun/VLCTube/commit/2ecb76f5a8538b8cf8c283c9dd1a2e921641f2bf)
+[Removing removing stuff. "New" formats.](https://github.com/jackun/VLCTube/commit/acad5ccb429177009669e79a27ed96aa18f42bd0)
+
+[Commits](https://github.com/jackun/VLCTube/compare/v59...v59.1)
+
+
+##Older
+//2014-06-25 Fix deciphering for firefox v30 and below
+//2014-05-21 Try to resume if unexpected EOS. Use bind(). Playlist next item fix.
+//2014-04-26 Watch later, regex fix, remove from watch later if viewing WL playlist, hover controls css
+//2014-04-26 Embedded crash. seekTo
+//2014-04-26 Incomplete quick fix the fix the fix for comments not loading, API calls maybe
+//2014-04-25 Fake Live formats for priority map
+//2014-04-24 Separate url map parse from DOM generation so we can fail earlier
+//           and allow flashplayer to take over. May need manual refreshing with SPF.
+//2014-04-24 this -> that. Embed font/css for icons
+//2014-04-24 Cleanup
+//2014-04-24 Alternate method for / quick fix for popups (security errors)
+//2014-04-17 Testing font Awesome Icons
+//2014-04-17 Option to auto select subtitle
+//2014-04-10 focus() leads to random scroll
+//2014-04-07 Signature deciphering flippity-boppity -_-
+//2014-03-30 Signature deciphering. Call focus() on vlc plugin
+//2014-03-13 Watch Later button option
+//2014-03-11 Fixed the playlist?
+//2014-03-10 Jump to timestamp option
+//2014-03-01 CSS hacks and fix some margins
+//2014-02-07 Fix popup. User page > video transition is borked still
+//2014-01-21 Live HLS stream test
+//2014-01-20 Can transition from main page > search results > video or user page > video without shitting itself?
+//2014-01-17 Thumbnails
+//2014-01-17 SPF hooking and volume restore changes
+//2014-01-17 Quick (aka not complete) fix for extra ajaxy 'tube
+//2014-01-06 Call stateUpdate on spf nav.
+//2014-01-04 Pass unsafeWindow to tampermonkey
+//2014-01-03 Mute button test

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,56 +1,56 @@
 ##In Development
 
-[Adjust compact volume button height](https://github.com/jackun/VLCTube/pull/52)
-[Visually limit scrollbar's knob's min/max size or position.](https://github.com/jackun/VLCTube/commit/b7af86cda7eaf0bff5de82beb7004b18902db677)
-[Just call play() on thumbnail click so jump-to-timestamp works then too.](https://github.com/jackun/VLCTube/commit/7c5ae4c9574c3cee8d605201b05fa052b109189e)
+ - [Adjust compact volume button height](https://github.com/jackun/VLCTube/pull/52)
+ - [Visually limit scrollbar's knob's min/max size or position.](https://github.com/jackun/VLCTube/commit/b7af86cda7eaf0bff5de82beb7004b18902db677)
+ - [Just call play() on thumbnail click so jump-to-timestamp works then too.](https://github.com/jackun/VLCTube/commit/7c5ae4c9574c3cee8d605201b05fa052b109189e)
 
 [Commits](https://github.com/jackun/VLCTube/compare/v59.7...master)
 
 ###v59.7 - 2015-03-18
-[Don't jump to timestamp when pausing/playing with play button.](https://github.com/jackun/VLCTube/commit/b386754c5cc631d0b1a51e66bff0fdbdf971e109)
-[Added customizable preset playback rate button as per issue #47.](https://github.com/jackun/VLCTube/pull/50)
+ - [Don't jump to timestamp when pausing/playing with play button.](https://github.com/jackun/VLCTube/commit/b386754c5cc631d0b1a51e66bff0fdbdf971e109)
+ - [Added customizable preset playback rate button as per issue #47.](https://github.com/jackun/VLCTube/pull/50)
 
 [Commits](https://github.com/jackun/VLCTube/compare/v59.6...v59.7)
 
 ###v59.6 - 2015-03-15
-[Add cache setting.](https://github.com/jackun/VLCTube/commit/14429032db237426df37538a223f869b8493a2e7)
+ - [Add cache setting.](https://github.com/jackun/VLCTube/commit/14429032db237426df37538a223f869b8493a2e7)
 
 [Commits](https://github.com/jackun/VLCTube/compare/v59.5...v59.6)
 
 ###v59.5 - 2015-02-23
-[Delay player loading when SPF navigating. Images etc should load now.](https://github.com/jackun/VLCTube/commit/cf1ead1093a8e38ed04deae5c1ef07b43916dc6f)
-[Exclude a embedding site if 'controls=0'. May have a custom player.](https://github.com/jackun/VLCTube/commit/9975631b9286cdc4f82103a306f3302e7d5d64e5)
+ - [Delay player loading when SPF navigating. Images etc should load now.](https://github.com/jackun/VLCTube/commit/cf1ead1093a8e38ed04deae5c1ef07b43916dc6f)
+ - [Exclude a embedding site if 'controls=0'. May have a custom player.](https://github.com/jackun/VLCTube/commit/9975631b9286cdc4f82103a306f3302e7d5d64e5)
 
 [Commits](https://github.com/jackun/VLCTube/compare/v59.4...v59.5)
 
 ###v59.4 - 2015-02-23
-[Exclude embedding sites: wimp.com (uses JW Player)](https://github.com/jackun/VLCTube/commit/e450d6813343092aef9796db95f56adbefb8144f)
-[Remove MPD generation. VLC can't play it anyway.](https://github.com/jackun/VLCTube/commit/28a9a7f2eee19c6754d9245d950c2906ccffa17e)
-[Nicer thumbnail.](https://github.com/jackun/VLCTube/commit/2ccca70182d8716979aa4ad392801f023520da64)
+ - [Exclude embedding sites: wimp.com (uses JW Player)](https://github.com/jackun/VLCTube/commit/e450d6813343092aef9796db95f56adbefb8144f)
+ - [Remove MPD generation. VLC can't play it anyway.](https://github.com/jackun/VLCTube/commit/28a9a7f2eee19c6754d9245d950c2906ccffa17e)
+ - [Nicer thumbnail.](https://github.com/jackun/VLCTube/commit/2ccca70182d8716979aa4ad392801f023520da64)
 
 [Commits](https://github.com/jackun/VLCTube/compare/v59.3...v59.4)
 
 ###v59.3 - 2015-02-22
-[Skip unavailable videos when SPF is enabled.](https://github.com/jackun/VLCTube/commit/b8265c4cd2b6708658206374e0ffa1b487d26c02)
+ - [Skip unavailable videos when SPF is enabled.](https://github.com/jackun/VLCTube/commit/b8265c4cd2b6708658206374e0ffa1b487d26c02)
 
 [Commits](https://github.com/jackun/VLCTube/compare/v59.2...v59.3)
 
 ###v59.2 - 2015-02-22
-[Can do away with waiting for yt.pubsub maybe.](https://github.com/jackun/VLCTube/commit/bc7021a61aa6549a5a6b995d4f8f35cda5da4bdf)
+ - [Can do away with waiting for yt.pubsub maybe.](https://github.com/jackun/VLCTube/commit/bc7021a61aa6549a5a6b995d4f8f35cda5da4bdf)
 
 [Commits](https://github.com/jackun/VLCTube/compare/v59.1...v59.2)
 
 ##v59.1 - 2015-02-22
-[Update README.md](https://github.com/jackun/VLCTube/commit/18607e782883b74f2c70112e2becd83cad1f49d0)
+ - [Update README.md](https://github.com/jackun/VLCTube/commit/18607e782883b74f2c70112e2becd83cad1f49d0)
 
 [Commits](https://github.com/jackun/VLCTube/compare/v59...v59.1)
 
 ##v59 - 2015-02-22
-[Try to delay loading the player until some javascript variables have been loaded.](https://github.com/jackun/VLCTube/commit/24f068746b02cab28d7b24b1b306bb51d10c6c4d)
-[Remove feather stuff.](https://github.com/jackun/VLCTube/commit/2ecb76f5a8538b8cf8c283c9dd1a2e921641f2bf)
-[Removing removing stuff. "New" formats.](https://github.com/jackun/VLCTube/commit/acad5ccb429177009669e79a27ed96aa18f42bd0)
+ - [Try to delay loading the player until some javascript variables have been loaded.](https://github.com/jackun/VLCTube/commit/24f068746b02cab28d7b24b1b306bb51d10c6c4d)
+ - [Remove feather stuff.](https://github.com/jackun/VLCTube/commit/2ecb76f5a8538b8cf8c283c9dd1a2e921641f2bf)
+ - [Removing removing stuff. "New" formats.](https://github.com/jackun/VLCTube/commit/acad5ccb429177009669e79a27ed96aa18f42bd0)
 
-[Commits](https://github.com/jackun/VLCTube/compare/v59...v59.1)
+[Commits](https://github.com/jackun/VLCTube/compare/v58.4...v59)
 
 
 ##Older

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+##TODO
+
+cleanup on aisle 3
+
+that=this to bind()
+https://www.youtube.com/watch?v=IHGEdi6HblI  rtmpe
+cipher https://www.youtube.com/watch?v=tka1jPGMyOs
+stream http://www.youtube.com/watch?v=jrZcAsPKK74
+ciphered http://www.youtube.com/watch?v=6CTHwEZK2JA
+unavail https://www.youtube.com/watch?v=gSEzGDzZ1dY
+has/had non-dash 1080p http://www.youtube.com/watch?v=-MJiR5IksEk
+subtitle test https://www.youtube.com/watch?v=sqll1Rib93g
+state play: 1, pause: 2, stop/end: 0


### PR DESCRIPTION
Start of cleaning up release notes and TODOs from script into separate files following [this format](http://www.mehdi-khalili.com/better-git-release-notes). Note that in RELEASE-NOTES.md, commit range links don't go anywhere since the repo wasn't tagged with versions (but I suppose these could be retro tagged.