### PR TITLE
Fix userscript to no longer reference userscripts.org

### DIFF
--- a/25318.user.js
+++ b/25318.user.js
@@ -19,8 +19,8 @@
 // @updateURL      https://github.com/jackun/VLCTube/raw/master/25318.user.js
 // @downloadURL    https://github.com/jackun/VLCTube/raw/master/25318.user.js
 // ==/UserScript==
-// @updateURL      http://userscripts.org:8080/scripts/source/25318.meta.js
-// @downloadURL    http://userscripts.org:8080/scripts/source/25318.user.js
+// @updateURL      https://greasyfork.org/scripts/1783-vlctube/code/VLCTube.meta.js
+// @downloadURL    https://greasyfork.org/scripts/1783-vlctube/code/VLCTube.meta.js
 // http://wiki.videolan.org/Documentation:WebPlugin
 // Tested on Arch linux, Fx35+, vlc 2.1.5, (or vlc-git & npapi-vlc-git from AUR)
 

--- a/25318.user.js
+++ b/25318.user.js
@@ -20,7 +20,7 @@
 // @downloadURL    https://github.com/jackun/VLCTube/raw/master/25318.user.js
 // ==/UserScript==
 // @updateURL      https://greasyfork.org/scripts/1783-vlctube/code/VLCTube.meta.js
-// @downloadURL    https://greasyfork.org/scripts/1783-vlctube/code/VLCTube.meta.js
+// @downloadURL    https://greasyfork.org/scripts/1783-vlctube/code/VLCTube.user.js
 // http://wiki.videolan.org/Documentation:WebPlugin
 // Tested on Arch linux, Fx35+, vlc 2.1.5, (or vlc-git & npapi-vlc-git from AUR)
 


### PR DESCRIPTION
The _userscripts.org_ website is no longer up, and while there are sites providing mirrors of the final state of the site (such as [userscripts-mirror.org](https://www.userscripts-mirror.org)), those mirrors are static and thus not suited for usage as the userscripts secondary update provider. This patch replaces the _userscripts.org_ references to the meta and user scripts with semi-identical references provided via [greasyfork.org](https://www.greasyfork.org).